### PR TITLE
Eag 102 readinessprobe

### DIFF
--- a/aws-eks-kubernetes/README.md
+++ b/aws-eks-kubernetes/README.md
@@ -52,6 +52,7 @@ No modules.
 | <a name="input_tls_cert_domain_name"></a> [tls\_cert\_domain\_name](#input\_tls\_cert\_domain\_name) | Domain Name of TLS Cert to use for Frontend ELB | `any` | n/a | yes |
 | <a name="input_web_cpu_request"></a> [web\_cpu\_request](#input\_web\_cpu\_request) | Requested CPU for Web Pod | `any` | n/a | yes |
 | <a name="input_web_memory_request"></a> [web\_memory\_request](#input\_web\_memory\_request) | Requested Memory for Web Pod | `any` | n/a | yes |
+| <a name="input_web_replica_count"></a> [web\_replica\_count](#input\_web\_replica\_count) | Number of Web Containers. | `any` | n/a | yes |
 
 ## Outputs
 

--- a/aws-eks-kubernetes/main.tf
+++ b/aws-eks-kubernetes/main.tf
@@ -35,7 +35,7 @@ resource "kubernetes_deployment" "deployment" {
         namespace = kubernetes_namespace.namespace.metadata.0.name
     }
     spec {
-        replicas = 1
+        replicas = var.web_replica_count
         selector {
             match_labels = {
                 app = "web"

--- a/aws-eks-kubernetes/main.tf
+++ b/aws-eks-kubernetes/main.tf
@@ -36,6 +36,15 @@ resource "kubernetes_deployment" "deployment" {
     }
     spec {
         replicas = var.web_replica_count
+
+        strategy {
+          type = "RollingUpdate"
+          rolling_update {
+            max_unavailable = 0
+            max_surge = 1
+          }
+        }
+
         selector {
             match_labels = {
                 app = "web"
@@ -72,6 +81,33 @@ resource "kubernetes_deployment" "deployment" {
                   cpu    = var.web_cpu_request
                   memory = var.web_memory_request
                 }
+              }
+              readiness_probe {
+                http_get {
+                  path = "/health"
+                  port = 8000
+                }
+                period_seconds = 5
+                timeout_seconds = 2
+                failure_threshold = 3
+              }
+              startup_probe {
+                http_get {
+                  path = "/health"
+                  port = 8000
+                }
+                period_seconds = 5
+                failure_threshold = 30
+                timeout_seconds = 2
+              }
+              liveness_probe {
+                http_get {
+                  path = "/health"
+                  port = 8000
+                }
+                period_seconds = 10
+                failure_threshold = 3
+                timeout_seconds = 2
               }
             }
             volume {

--- a/aws-eks-kubernetes/variables.tf
+++ b/aws-eks-kubernetes/variables.tf
@@ -10,6 +10,10 @@ variable "cron_replica_count" {
     description = "Number of Cron Containers. Set this to zero to turn off cron in EKS"
 }
 
+variable "web_replica_count" {
+    description = "Number of Web Containers."
+}
+
 variable "env_vars" {
   description = "Environment variables for Kubernetes deployment"
   type        = list(object({


### PR DESCRIPTION
- startupProbe prevents readiness checks from running too early during cold start.
- readinessProbe keeps the pod out of the service endpoints until /health is truly responsive (DB reachable, app bound).
- with maxUnavailable=0, maxSurge=1, new ready pods come online before old ones go away.